### PR TITLE
Don't append a newline to command output

### DIFF
--- a/src/SlimCLIRunner.php
+++ b/src/SlimCLIRunner.php
@@ -87,7 +87,7 @@ class SlimCLIRunner
                 }
 
                 $cli_response = $task->command($args);
-                $response->getBody()->write($cli_response . "\n");
+                $response->getBody()->write($cli_response);
             } else {
                 $response->getBody()->write("Command not found\n");
             }


### PR DESCRIPTION
In the current code a newline is always appended to the return value of the `command()` method. This causes issues when you want to use a command in a cronjob, because cron will then always send an e-mail, even if the return value is empty.

So I propose to remove the newline and let it be the responsibility of the actual command to add a newline.