### PR TITLE
[Issue-20] PHP 8 Support by upgrading slim/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "slim/psr7": "^0.6.0",
+        "slim/psr7": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "php-di/php-di": "^6.0"


### PR DESCRIPTION
This PR fixes #20 by upgrading the slim/psr7 from `^0.6.0` to `^1.0`.