### PR TITLE
Support PHP-DI 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "slim/psr7": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "php-di/php-di": "^6.0"
+        "php-di/php-di": "^6.0||^7.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5"


### PR DESCRIPTION
Since this project is only using `\DI\Container::get` method, this change will not break anything according to https://github.com/PHP-DI/PHP-DI/blob/master/doc/migration/7.0.md