### PR TITLE
Disable cli runner on phpunit

### DIFF
--- a/src/CliRunner.php
+++ b/src/CliRunner.php
@@ -46,7 +46,7 @@ class CliRunner implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (PHP_SAPI !== 'cli') {
+        if (PHP_SAPI !== 'cli' || defined('PHPUNIT_COMPOSER_INSTALL')) {
             return $handler->handle($request);
         }
 


### PR DESCRIPTION
Running unit tests with phpunit when cli runner is set up as middleware, makes the cli runner try to run any parameters given for the phpunit cli. So I get errors like this:

`adrianfalleiro\SlimCliRunner\CliException: Command __default not found`

Here's a suggestion for a fix...